### PR TITLE
Added RESTEasy fix for getClasses()

### DIFF
--- a/solution/src/main/java/eu/agilejava/mvc/config/ApplicationConfig.java
+++ b/solution/src/main/java/eu/agilejava/mvc/config/ApplicationConfig.java
@@ -36,6 +36,7 @@ import javax.mvc.security.Csrf;
 import javax.ws.rs.ApplicationPath;
 import javax.ws.rs.core.Application;
 import org.mvcspec.ozark.Properties;
+import org.mvcspec.ozark.bootstrap.OzarkCoreFeature;
 
 /**
  *
@@ -52,6 +53,10 @@ public class ApplicationConfig extends Application {
         set.add(PartTwoAdvancedController.class);
         set.add(PartThreeGreetingController.class);
         set.add(PartThreeConfirmationController.class);
+
+        // Only required for Wildfly if you register resources manually via this method
+        //set.add(OzarkCoreFeature.class);
+
         return set;
     }
 


### PR DESCRIPTION
If you deploy your MVC app to Wildfly and implement `Application#getClasses()` manually, the Ozark feature isn't registered automatically. Therefore, you have to add `OzarkCoreFeature` to the list of resources/providers.